### PR TITLE
Fixes typo.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,7 +5,7 @@ cmake_minimum_required (VERSION 3.5)
 add_definitions(-std=c++11)
 
 set(CXX_FLAGS "-Wall")
-set(CMAKE_CXX_FLAGS, "${CXX_FLAGS}")
+set(CMAKE_CXX_FLAGS "${CXX_FLAGS}")
 
 set(sources src/ukf.cpp src/main.cpp src/tools.cpp)
 


### PR DESCRIPTION
Removes comma in set(CMAKE_CXX_FLAGS "${CXX_FLAGS}") that was stopping the compilation flags from working.